### PR TITLE
ci: move actions to current majors and raise pillow/requests floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   docs_linter_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install yamllint
         run: pip install yamllint
@@ -32,7 +32,7 @@ jobs:
           yamllint --no-warnings .github/workflows mkdocs.yml
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809  # v20.0.0
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff  # v24.2.0
         with:
           globs: |
             docs/**/*.md
@@ -46,10 +46,10 @@ jobs:
   layout_linter_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "22"
 
@@ -77,9 +77,9 @@ jobs:
       - docs_linter_checks
       - layout_linter_checks
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
@@ -94,9 +94,9 @@ jobs:
     needs:
       - dependency_audit_checks
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
@@ -115,7 +115,7 @@ jobs:
       - dependency_audit_checks
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install hadolint
         run: |
@@ -141,15 +141,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Cache pip
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
@@ -188,15 +188,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Cache pip
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
@@ -248,7 +248,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
 
       - name: Create GitHub Deployment
         uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a  # v2.0.8

--- a/.github/workflows/release-from-notes.yml
+++ b/.github/workflows/release-from-notes.yml
@@ -18,17 +18,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Cache pip
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
@@ -85,7 +85,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,11 @@ pymdown-extensions==11.0.2
 Pygments==2.21.0
 
 # ─── Social cards (Material plugin dependency) ──────────────────────────────
-pillow>=10.0.0
+pillow>=12.3.0
 cairosvg>=2.9.0
 
 # ─── Transitive deps (pinned for CVE fixes) ─────────────────────────────────
-requests>=2.34.0
+requests>=2.34.2
 cryptography>=50.0.0
 
 # ─── Runtime ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Collapses eight queued Dependabot pull requests into one change. They each rewrite neighbouring lines of `ci.yml` or `requirements.txt`, so merging them individually means a conflict and a rebase after every single merge — #76 already hit exactly that after #74 landed.

Supersedes #70, #71, #73, #75, #76, #77, #78, #79 and #80; Dependabot closes them once this is on `develop`.

## Actions

| Action | From | To | Pin verified |
| --- | --- | --- | --- |
| `actions/checkout` | v4.1.1 | v7.0.1 | `3d3c42e` = `refs/tags/v7.0.1` |
| `actions/setup-python` | v5.0.0 | v7.0.0 | `5fda3b9` = `refs/tags/v7.0.0` |
| `actions/setup-node` | v6.3.0 | v7.0.0 | `8207627` = `refs/tags/v7.0.0` |
| `actions/cache` | v5.0.4 | v6.1.0 | `55cc834` = `refs/tags/v6.1.0` |
| `actions/deploy-pages` | v4.0.5 | v5.0.0 | `cd2ce8f` = `refs/tags/v5.0.0` |
| `DavidAnson/markdownlint-cli2-action` | v17.0.0 | v24.2.0 | `21c1be1` = `refs/tags/v24.2.0` |
| `softprops/action-gh-release` | v2.6.2 | v3.0.2 | `3d0d988` = `refs/tags/v3.0.2` |

Every SHA was checked against the upstream tag with `git ls-remote` rather than trusted from the PR title.

What is actually in these majors: the Node 24 runtime (which the runners already force — the previous runs logged "Node.js 20 is deprecated … being forced to run on Node.js 24"), ESM packaging, and in checkout v7 a refusal to check out fork PRs under `pull_request_target` / `workflow_run`. This repo triggers on `pull_request`, so that hardening changes nothing here.

**The markdownlint pin was mislabelled.** `db43aef` is `v17.0.0`, but the comment next to it read `# v20.0.0`. Dependabot left the stale comment untouched because it did not match the version being replaced, so the PR would have carried the lie forward — the new line says `# v24.2.0`, which is what the SHA actually is. Worth a glance at how that comment drifted, since a version comment is the only human-readable part of a SHA pin.

## Floors

`pillow >=10.0.0 → >=12.3.0`, `requests >=2.34.0 → >=2.34.2`. Lower bounds, not pins — pip already resolved to these, so nothing changes at build time.

## Validation

- `actionlint` 1.7.12 on both workflows — clean.
- `yamllint --no-warnings .github/workflows mkdocs.yml` — clean (same invocation as `docs_linter_checks`).
- markdownlint-cli2 0.23.2 / markdownlint 0.41.1 (what v24.2.0 bundles, up from 0.35) run over `docs/**`, `labs/**` and the root docs: **94 files, 0 issues**. This is the one bump that could newly fail a previously passing repo, so it was checked before the CI ever saw it.
- `pip check` and `pip-audit -r requirements.txt` in a clean venv — no broken requirements, no known vulnerabilities.

`deploy-pages` is only exercised on push to `develop`, so its bump gets tested on the merge commit. The v5 pairing is low-risk: `upload-pages-artifact@v5` is already on `develop` and the last push run deployed the site green with `deploy-pages@v4.0.5`, and v5 is a Node 24 bump with no change to the artifact contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzTNnRHve5ZKiam3GFZaBd)_